### PR TITLE
Extract 1st frame from GIF animations

### DIFF
--- a/thumberd/thumberd.go
+++ b/thumberd/thumberd.go
@@ -32,7 +32,7 @@ var client http.Client
 var version string
 
 const maxDimension = 65000
-const maxPixels = 10000000
+const maxPixels = 100000000
 const defaultScheme = "http"
 
 var http_stats struct {
@@ -278,6 +278,7 @@ func thumbServer(w http.ResponseWriter, r *http.Request, sem chan int) {
 		FormatOutput: "",
 		// クロップ面積制限(0 == 制限なし)
 		CropAreaLimitation: 0,
+		MaxPixels: maxPixels,
 	}
 
 	if path[0] != '/' {

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -170,6 +170,103 @@ func isOutputTransparent(inputFormat, outputFormat string) bool {
 	return false
 }
 
+// This function comes from yoya san's gist. For more details, see: https://gist.github.com/yoya/2ae952716dbf70bc749181781eda27a8
+func extractGIF1stFrame(bytes []byte) (int, error) {
+	size := len(bytes)
+	if size < 13 {
+		return size, errors.New("too short header")
+	}
+	flags := bytes[10]
+	globalColorTableFlag := (flags & 0x80) >> 7
+	sizeOfGlobalColorTable := (flags & 0x07)
+	var offset = 13
+	if globalColorTableFlag != 0 {
+		colorTableSize := int(math.Pow(2, float64(sizeOfGlobalColorTable+1)))
+		offset += 3 * colorTableSize
+		if size < offset {
+			return size, errors.New("too short global colorTable")
+		}
+	}
+	for {
+		if size < (offset + 1) {
+			return size, errors.New("missing separator")
+		}
+		separator := bytes[offset]
+		offset++
+		switch separator {
+		case 0x3B: // Trailer
+		case 0x21: // Extention
+			if size < (offset + 2) {
+				return size, errors.New("missing extention block header")
+			}
+			extensionBlockLabel := bytes[offset]
+			extensionDataSize := bytes[offset+1]
+			offset += 2 + int(extensionDataSize)
+			if size < offset {
+				return size, errors.New("too short extension block")
+			}
+			if extensionBlockLabel == 0xff { // Application Extension
+				for {
+					if size < (offset + 1) {
+						return size, errors.New("missing extension subblock size field")
+					}
+					subBlockSize := bytes[offset]
+					offset++
+					if subBlockSize == 0 {
+						break
+					}
+					offset += int(subBlockSize)
+					if size < offset {
+						return size, errors.New("to short extension subblock")
+					}
+				}
+			} else {
+				offset++ // extensionBlock Trailer
+			}
+		case 0x2C: // Image
+			if size < (offset + 9) {
+				return size, errors.New("too short image header")
+			}
+			flags := bytes[offset+8]
+			localColorTableFlag := (flags & 0x80) >> 7
+			sizeOfLocalColorTable := (flags & 0x07)
+			offset += 9
+			if localColorTableFlag != 0 {
+				colorTableSize := int(math.Pow(2, float64(sizeOfLocalColorTable+1)))
+				offset += 3 * colorTableSize
+				if size < offset {
+					return size, errors.New("too short local colorTable")
+				}
+			}
+			offset++ // LZWMinimumCodeSize
+			for {
+				if size < (offset + 1) {
+					return size, errors.New("missing image subblock size field")
+				}
+				subBlockSize := bytes[offset]
+				offset++
+				if subBlockSize == 0 {
+					break
+				}
+				offset += int(subBlockSize)
+				if size < offset {
+					return size, errors.New("too short image subblock")
+				}
+			}
+			if size < (offset + 1) {
+				return size, errors.New("missing separator for trailer overwrite")
+			}
+			bytes[offset] = 0x3B // trailer overwrite
+		default:
+			// nothing to do
+		}
+		if separator == 0x3B {
+			break
+		}
+	}
+	return offset, nil
+}
+
 /*
  * サムネール処理
  */
@@ -201,6 +298,13 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 	srcWidth := float64(mw.GetImageWidth())
 	srcHeight := float64(mw.GetImageHeight())
 
+	if mw.GetImageFormat() == "GIF" {
+		_, err := extractGIF1stFrame(bytes)
+		if err != nil {
+			glog.Error("extractGIF1stFrame failed" + err.Error())
+			log.Println("extractGIF1stFrame failed" + err.Error())
+		}
+	}
 
 	pixelNum := mw.GetImageWidth() * mw.GetImageHeight()
 	if uint(pixelNum) > params.MaxPixels {

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -47,7 +47,7 @@ func round(f float64) uint {
 	return uint(math.Floor(f + .5))
 }
 
-func round_int(f float64) int {
+func roundInt(f float64) int {
 	return int(math.Floor(f + .5))
 }
 
@@ -157,24 +157,16 @@ func isFormatTransparent(format string) bool {
 	return false
 }
 
-func isOutputTransparent(input_format, output_format string) bool {
-	if isFormatTransparent(output_format) {
+func isOutputTransparent(inputFormat, outputFormat string) bool {
+	if isFormatTransparent(outputFormat) {
 		return true
-	} else if output_format == "" {
-		if isFormatTransparent(input_format) {
+	} else if outputFormat == "" {
+		if isFormatTransparent(inputFormat) {
 			return true
 		}
 	}
 	return false
 }
-
-/*
- * ImageMagick 初期化
- */
-var imagick_initialized = func() bool {
-	imagick.Initialize()
-	return true
-}()
 
 /*
  * サムネール処理
@@ -343,8 +335,8 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 
 	// JPEG scaling decode hinting
 	if virtualMappedWidth < srcWidth/2 && virtualMappedHeight < srcHeight/2 {
-		jpeg_size := fmt.Sprintf("%dx%d", round_int(virtualMappedWidth*2), round_int(virtualMappedHeight*2))
-		mw.SetOption("jpeg:size", jpeg_size)
+		jpegSize := fmt.Sprintf("%dx%d", roundInt(virtualMappedWidth*2), roundInt(virtualMappedHeight*2))
+		mw.SetOption("jpeg:size", jpegSize)
 	}
 
 	// Decode Image
@@ -386,10 +378,10 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 	} else if params.CropMode == 1 {
 		// クロップとリサイズを同時に行う
 		// fmt.Printf("TransformImage:  cropX:%d cropY:%d cropWidth:%f, cropHeight:%f destWidth:%f, destHeight:%f\n", cropX, cropY, cropWidth, cropHeight, destWidth, destHeight)
-		geo_src := fmt.Sprintf("%dx%d+%d+%d", round(cropWidth), round(cropHeight), cropX, cropY)
-		geo_dest := fmt.Sprintf("%dx%d!", round(destWidth), round(destHeight))
+		geoSrc := fmt.Sprintf("%dx%d+%d+%d", round(cropWidth), round(cropHeight), cropX, cropY)
+		geoDest := fmt.Sprintf("%dx%d!", round(destWidth), round(destHeight))
 		//		fmt.Println("geo_src, geo_dest: ", geo_src, geo_dest)
-		mw2 := mw.TransformImage(geo_src, geo_dest)
+		mw2 := mw.TransformImage(geoSrc, geoDest)
 		defer mw2.Destroy()
 		err := mw2.GetLastError()
 		if err != nil {
@@ -472,8 +464,8 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 			yRatio = getVertical(params.ImageOverlapGravity)
 		}
 
-		iox = round_int(xRatio * (mappedWidth - float64(imageOverlapWidth)))
-		ioy = round_int(yRatio * (mappedHeight - float64(imageOverlapHeight)))
+		iox = roundInt(xRatio * (mappedWidth - float64(imageOverlapWidth)))
+		ioy = roundInt(yRatio * (mappedHeight - float64(imageOverlapHeight)))
 		if (float64(imageOverlapWidth) < srcOverlapWidth/2) &&
 			(float64(imageOverlapHeight) < srcOverlapHeight/2) {
 			jpeg_size := fmt.Sprintf("%dx%d", uint(imageOverlapWidth*2), uint(imageOverlapHeight*2))

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -2,6 +2,7 @@
 package thumbnail
 
 import (
+	"errors"
 	"fmt"
 	"github.com/golang/glog"
 	"gopkg.in/gographics/imagick.v2/imagick"
@@ -41,6 +42,7 @@ type ThumbnailParameters struct {
 	HttpAvoidChunk          bool
 	FormatOutput            string
 	CropAreaLimitation      float64
+	MaxPixels               uint
 }
 
 func round(f float64) uint {
@@ -198,6 +200,14 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 	mw.SetFirstIterator()
 	srcWidth := float64(mw.GetImageWidth())
 	srcHeight := float64(mw.GetImageHeight())
+
+
+	pixelNum := mw.GetImageWidth() * mw.GetImageHeight()
+	if uint(pixelNum) > params.MaxPixels {
+		glog.Error("origin image size too big, exceed max pixel num")
+		log.Println("origin image size too big, exceed max pixel num")
+		return errors.New("origin image size too big, exceed max pixel num")
+	}
 
 	var cropX uint = 0
 	var cropY uint = 0


### PR DESCRIPTION
Sometimes we had troubles with animated GIF, since decoding the all frames into main memory uses too much memory area.

We are already extracting the 1st frame of animated GIF, but the way to do so is not efficient. Now @yoya have implemented more smart way of extracting, we want to adopt it.
