### PR TITLE
Fix typo in README. s/thumber/thumberd/

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ go install gopkg.in/gographics/imagick.v2/imagick
 - yoya-thumber
 ```
 $ go get github.com/smartnews/yoya-thumber/thumberd
-$ go install github.com/smartnews/yoya-thumber/thumber
+$ go install github.com/smartnews/yoya-thumber/thumberd
 ```
 
 ## Install (Ubuntu)


### PR DESCRIPTION
I found a typo in README.
It should be "thumberd" not "thumber".
