### PR TITLE
Add support for special transport configuration for HTTP/2 requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ RUN \
     \
     go get gopkg.in/gographics/imagick.v2/imagick && \
     go get github.com/golang/glog && \
-    go get github.com/naoina/toml
+    go get github.com/naoina/toml && \
+    go get golang.org/x/net/http2
 
 ADD thumberd /go/src/github.com/smartnews/yoya-thumber/thumberd
 ADD thumbnail /go/src/github.com/smartnews/yoya-thumber/thumbnail

--- a/files/thumberd.toml
+++ b/files/thumberd.toml
@@ -1,12 +1,20 @@
 # TOML document for thumberd config
 
 [font]
-
-name = ["IPAGothic"]
+	name = ["IPAGothic"]
 
 [http]
-        avoid_chunk = false
-        user_agent = "yoya-thumber"
+	avoid_chunk = false
+	user_agent = "yoya-thumber"
+
+[domain]
+        [domain."www.example.com"]
+                MaxHeaderListSize = 32768
+                DisableCompression = true
+                AllowHTTP = false
+
+        [domain."www.example.org"]
+                MaxHeaderListSize = 32768
 
 [image]
 	background_color = "#ffffff00"


### PR DESCRIPTION
This change is for supporting special [Transport configuration](https://godoc.org/golang.org/x/net/http2#Transport) for HTTP/2 requests.