### PR TITLE
Fix ImageMagick's url to use GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,10 @@ RUN \
         /usr/share/doc-base && \
     \
     cd /usr/local/src && \
-    curl -fsSL https://launchpad.net/imagemagick/main/${IMAGEMAGICK_VERSION}/+download/ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz > \
+    curl -fsSL https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz > \
           ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
     tar xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
-    cd /usr/local/src/ImageMagick-${IMAGEMAGICK_VERSION} && \
+    cd /usr/local/src/ImageMagick6-${IMAGEMAGICK_VERSION} && \
     ./configure \
         '--prefix=/usr/local' \
         '--disable-openmp' \


### PR DESCRIPTION
- Fix ImageMagick's url to use GitHub archive's url