### PR TITLE
Honor origin's HTTP status code

### DIFF
--- a/thumberd/thumberd.go
+++ b/thumberd/thumberd.go
@@ -187,7 +187,7 @@ func myClientImageGet(imageUrl string, referer string, userAgent string) (*http.
 	srcReader, err = client.Do(req)
 	if err != nil {
 		glog.Warning("imageUrl not find " + imageUrl)
-		return nil, err, srcReader.StatusCode
+		return nil, err, http.StatusBadRequest
 	}
 	// 200 以外はエラーにする (302 とかはどうしよう？)
 	if srcReader.StatusCode != http.StatusOK {


### PR DESCRIPTION
This PR resolve issue https://github.com/smartnews/yoya-thumber/issues/9

In an environment with CDN middleboxes, if yoya-thumber receive StatusNotFound(404) from origin and send StatusBadGateway(502) to the client, the contents will not be cached on CDN and cause a load problem.