### PR TITLE
Support for HEIF Image Format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
-ENV IMAGEMAGICK_VERSION  6.9.9-15
+ENV IMAGEMAGICK_VERSION 6.9.11-6
+ENV LIBHEIF_VERSION 1.6.2
 
 ENV GOLANG_VERSION 1.9.1
 
@@ -22,10 +23,12 @@ RUN \
         git \
         curl \
         ca-certificates \
+        automake  libtool \
         libjpeg-turbo8-dev \
         libpng12-dev \
         libgif-dev \
         libwebp-dev \
+        libx265-dev  libde265-dev \
         libfontconfig1-dev \
         fonts-ipafont-gothic \
         xz-utils && \
@@ -39,6 +42,21 @@ RUN \
         /usr/share/doc-base && \
     \
     cd /usr/local/src && \
+    curl -fsSL https://github.com//strukturag/libheif/archive/v${LIBHEIF_VERSION}.tar.gz > \
+          libheif-${LIBHEIF_VERSION}.tar.gz && \
+   tar xf libheif-${LIBHEIF_VERSION}.tar.gz && \
+   cd /usr/local/src/libheif-${LIBHEIF_VERSION} && \
+    ./autogen.sh && \
+    ./configure \
+        '--prefix=/usr/local' \
+        'CFLAGS=-O3 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -grecord-gcc-switches -m64 -mtune=generic' \
+        'LDFLAGS=-Wl,-z,relro' \
+        'CXXFLAGS=-O3 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -grecord-gcc-switches -m64 -mtune=generic' && \
+    make && \
+    make install && \
+    rm -rf /usr/local/src/* && \
+    \
+    cd /usr/local/src && \
     curl -fsSL https://github.com/ImageMagick/ImageMagick6/archive/${IMAGEMAGICK_VERSION}.tar.gz > \
           ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
     tar xf ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz && \
@@ -48,6 +66,7 @@ RUN \
         '--disable-openmp' \
         '--disable-opencl' \
         '--with-webp' \
+        '--with-heic' \
         '--with-fontconfig' \
         '--disable-dependency-tracking' \
         '--enable-shared' \
@@ -58,7 +77,7 @@ RUN \
         '--with-ltdl-lib=/usr/lib64' \
         '--without-perl' \
         'CFLAGS=-O3 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -grecord-gcc-switches -m64 -mtune=generic' \
-        'LDFLAGS=-Wl,-z,relro' \
+        'LDFLAGS=-Wl,-z,relro,-rpath,/usr/local/lib' \
         'CXXFLAGS=-O3 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -grecord-gcc-switches -m64 -mtune=generic' && \
     make && \
     make install && \

--- a/thumberd/thumberd.go
+++ b/thumberd/thumberd.go
@@ -473,6 +473,8 @@ func thumbServer(w http.ResponseWriter, r *http.Request, sem chan int) {
 		content_type = "image/png"
 	case "gif":
 		content_type = "image/gif"
+	case "heic", "heif":
+		content_type = "image/heic"
 	}
 
 	fmt.Printf("%#v\n", params)

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -155,8 +155,6 @@ func isFormatTransparent(format string) bool {
 		return true
 	case "gif":
 		return true
-	case "heic":
-		return true
 	}
 	return false
 }

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -485,7 +485,7 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 				cropWidth = srcWidth
 				cropHeight = (srcWidth / destAspect)
 				// 画像の面積がクロップ面積制限以下のサイズになった場合は下限値に補正する
-				if !largerThanSrc && srcAspect / destAspect < params.CropAreaLimitation {
+				if !largerThanSrc && srcAspect/destAspect < params.CropAreaLimitation {
 					var oldDestHeight = destHeight
 					cropHeight = (srcWidth / srcAspect * params.CropAreaLimitation)
 					destHeight = (destWidth / srcAspect * params.CropAreaLimitation)
@@ -497,7 +497,7 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 				cropWidth = (srcHeight * destAspect)
 				cropHeight = srcHeight
 				// 画像の面積がクロップ面積制限以下のサイズになった場合は下限値に補正する
-				if !largerThanSrc && destAspect / srcAspect < params.CropAreaLimitation {
+				if !largerThanSrc && destAspect/srcAspect < params.CropAreaLimitation {
 					var oldDestWidth = destWidth
 					cropWidth = (srcHeight * srcAspect * params.CropAreaLimitation)
 					destWidth = (destHeight * srcAspect * params.CropAreaLimitation)


### PR DESCRIPTION
This is the implementation needed to support HEIF.

- Prepare the libheif environment with Dockerfile and embed it in ImageMagick.
- Add HEIF to the currently supported formats JPEG, GIF, PNG, WebP, and BMP.
- ImageMagick does not support transparency in HEIF specifications, so it is treated as having no transparency.
- Set the ContentType to image/heic.
- Magick Check starts with ftyp and the major brand is either heic, heix or mif1.

Related issues: https://github.com/smartnews/yoya-thumber/issues/22