### PR TITLE
Set Image Quality parameter for HEIC.

### DIFF
--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -804,8 +804,8 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 			return err
 		}
 	}
-
-	err = mw.SetImageCompressionQuality(uint(params.Quality))
+	err = mw.SetImageCompressionQuality(uint(params.Quality)) // JPEG, WebP
+	err = mw.SetCompressionQuality(uint(params.Quality))      // HEIC
 	if err != nil {
 		panic(err)
 	}

--- a/thumbnail/thumbnail_magick.go
+++ b/thumbnail/thumbnail_magick.go
@@ -804,8 +804,13 @@ func MakeThumbnailMagick(src io.Reader, dst http.ResponseWriter, params Thumbnai
 			return err
 		}
 	}
-	err = mw.SetImageCompressionQuality(uint(params.Quality)) // JPEG, WebP
-	err = mw.SetCompressionQuality(uint(params.Quality))      // HEIC
+	// JPEG, WebP
+	err = mw.SetImageCompressionQuality(uint(params.Quality))
+	if err != nil {
+		panic(err)
+	}
+	// HEIC
+	err = mw.SetCompressionQuality(uint(params.Quality))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
the problem that quality parameter does not work in HEIC output.
https://github.com/smartnews/yoya-thumber/issues/27

When ImageMagick outputs JPEG or WebP, it refers to image->quality for compression.

- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/coders/jpeg.c#L2487
- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/coders/webp.c#L946

HEIC does so by referring to image_info->quality. (Including many other codecs such as JP2 and TIFF, etc...)

- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/coders/heic.c#L709

The difference is probably due to the fact that JPEG estimates the quality from the quantization table when reading it, so the quality of the image structure is important to reflect on output.  WebP may have imitated it. I think that other codecs use image_info as the metadata to instruct image processing.

The -quality option of the convert command is set to image_info->quality, and then copies the quality from image_info when creating the image structure with the substitute module, so it can be reflected in all JPEG, WebP, and HEIC output compression.

- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/wand/mogrify.c#L7399
- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/magick/constitute.c#L153
- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/magick/image.c#L224


GoImagick uses MagickWand API and we uses only GetImagesBlob, so it's not copied from image_info to the image structure. So unless you call SetImageCompressionQuality and set the value of image_info explicitly, HEIC compression will not be affected.

- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/wand/magick-image.c#L10296
- https://github.com/ImageMagick/ImageMagick6/blob/6.9.11-18/wand/magick-property.c#L1971